### PR TITLE
Microsoft Edge ("Spartan"/IE12) natively supports `document.currentScript`

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,9 +5,12 @@
 
 Polyfill of HTML5's [`document.currentScript`](http://www.whatwg.org/specs/web-apps/current-work/multipage/dom.html#dom-document-currentscript) for IE 6-10 _**ONLY**_.
 
+
 ## Public Service Announcement (PSA)
 
-This polyfill will not work in IE11 because of a critical design choice made Microsoft ("Don't Call Me IE!") [\[1\]](https://msdn.microsoft.com/en-us/library/ie/bg182625.aspx)[\[2\]](https://msdn.microsoft.com/en-us/library/ie/dn384059.aspx)[\[3\]](http://www.nczonline.net/blog/2013/07/02/internet-explorer-11-dont-call-me-ie/)[\[4\]](http://blog.getify.com/ie11-please-bring-real-script-preloading-back/) in order to avoid consumers receiving an unnecessarily downgraded experience on websites that were making logic branch and feature decisions based on browser detection rather than feature detection. If you want to help ensure that IE12+ (and/or the Microsoft "Spartan" browser) adds native `document.currentScript` support, please upvote [this issue on the IE Platform Suggestion Forum](https://wpdev.uservoice.com/forums/257854-internet-explorer-platform/suggestions/6965085-support-document-currentscript-property)!
+This polyfill will not work in IE11 because of a critical design choice made Microsoft ("Don't Call Me IE!") [\[1\]](https://msdn.microsoft.com/en-us/library/ie/bg182625.aspx)[\[2\]](https://msdn.microsoft.com/en-us/library/ie/dn384059.aspx)[\[3\]](http://www.nczonline.net/blog/2013/07/02/internet-explorer-11-dont-call-me-ie/)[\[4\]](http://blog.getify.com/ie11-please-bring-real-script-preloading-back/) in order to avoid consumers receiving an unnecessarily downgraded experience on websites that were making logic branch and feature decisions based on browser detection rather than feature detection.
+
+However, Microsoft Edge (a.k.a. "Spartan", a.k.a. IE12) _does_ natively support `document.currentScript`. This is likely due in part to you lovely consumers upvoting [this issue on the IE Platform Suggestion Forum](https://wpdev.uservoice.com/forums/257854-internet-explorer-platform/suggestions/6965085-support-document-currentscript-property), so _thank you!_
 
 
 ## Overview
@@ -24,6 +27,7 @@ In other words, if code is being operated on _after_ its **initial** evaluation 
 
 If you are interested in getting the currently _executing_ script [regardless of the source/trigger of the exection], take a look at [JamesMGreene/currentExecutingScript](https://github.com/JamesMGreene/currentExecutingScript) instead.
 
+
 ## Browser Compatibility
 
 | Browser | Version  | Works? | Notes                                 |
@@ -33,8 +37,10 @@ If you are interested in getting the currently _executing_ script [regardless of
 | IE      |        8 |  :+1:  | Must use `document._currentScript()`. |
 | IE      |        9 |  :+1:  |                                       |
 | IE      |       10 |  :+1:  |                                       |
-| IE      |       11 |  :-1:  | IE removed `script.readyState` but didn't add `document.currentScript` yet! :astonished: |
+| IE      |       11 |  :-1:  | IE removed `script.readyState` but didn't add `document.currentScript` yet! :astonished: See [PSA](#public-service-announcement-psa) for more info. |
+| Edge    |        * |  :+1:  | Natively supports `document.currentScript`. |
 | *       |        * | :question: | Only if the browser natively supports `document.currentScript`. |
+
 
 ## Usage
 
@@ -44,11 +50,12 @@ If you are interested in getting the currently _executing_ script [regardless of
 var scriptEl = document.currentScript;
 ```
 
-### IE 6-8 (and IE 9-10
+### IE 6-8 (and IE 9-10)
 
 ```js
 var scriptEl = document._currentScript();
 ```
+
 
 ## Configuration
 
@@ -62,9 +69,11 @@ However, if you would prefer to disallow that fallback behavior, you can do so a
 document._currentScript.doNotDeferToNativeMethod = true;
 ```
 
+
 ## Other Documentation
 
 - MDN docs: https://developer.mozilla.org/en-US/docs/Web/API/document.currentScript
+
 
 ## Errata
 


### PR DESCRIPTION
Closes #12.