### PR TITLE
v1.0.9 - Downgrade Karma devDep to 0.12.x to hopefully fix IE6/IE7 VM timeouts

### DIFF
--- a/dist/document.currentScript.js
+++ b/dist/document.currentScript.js
@@ -4,7 +4,7 @@
  * Copyright (c) 2015 James M. Greene
  * Licensed MIT
  * https://github.com/JamesMGreene/document.currentScript
- * v1.0.8
+ * v1.0.9
  */
 (function() {
 

--- a/dist/document.currentScript.min.js
+++ b/dist/document.currentScript.min.js
@@ -4,7 +4,7 @@
  * Copyright (c) 2015 James M. Greene
  * Licensed MIT
  * https://github.com/JamesMGreene/document.currentScript
- * v1.0.8
+ * v1.0.9
  */
 !function(){
 // Top-level API (compliant with `document.currentScript` specifications)

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "currentscript",
   "title": "document.currentScript",
-  "version": "1.0.8",
+  "version": "1.0.9",
   "description": "Polyfill for `document.currentScript`.",
   "keywords": [
     "browser",
@@ -43,8 +43,8 @@
     "grunt-contrib-concat": "^0.5.1",
     "grunt-contrib-jshint": "^0.11.3",
     "grunt-contrib-uglify": "^0.11.0",
-    "grunt-karma": "^0.12.1",
-    "karma": "^0.13.15",
+    "grunt-karma": "0.11.x",
+    "karma": "0.12.x",
     "karma-chrome-launcher": "^0.2.2",
     "karma-firefox-launcher": "^0.1.7",
     "karma-phantomjs-launcher": "^0.2.1",


### PR DESCRIPTION
Related: https://github.com/karma-runner/karma/issues/983